### PR TITLE
[119] Add `subprocess` backend supporting Python and R

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -301,3 +301,5 @@ SOCIALACCOUNT_FORMS = {"signup": "etlman.users.forms.UserSocialSignupForm"}
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+ETLMAN_BACKEND = env("ETLMAND_BACKEND", default="subprocess")

--- a/etlman/backends/__init__.py
+++ b/etlman/backends/__init__.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def get_backend():
+    if settings.ETLMAN_BACKEND == "subprocess":
+        from .subprocess_backend import SubprocessBackend
+
+        return SubprocessBackend()
+    raise ValueError(f"ETLMAN_BACKEND {settings.ETLMAN_BACKEND} is not supported.")

--- a/etlman/backends/subprocess_backend.py
+++ b/etlman/backends/subprocess_backend.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+import tempfile
+
+
+class SubprocessBackend:
+    RUN_ARGS = {
+        ("windows", "python"): ["Python.exe"],
+        ("windows", "r"): ["Rscript.exe"],
+        ("posix", "python"): ["/usr/bin/env", "python"],
+        ("posix", "r"): ["/usr/bin/env", "Rscript"],
+    }
+
+    def _get_run_args(self, language: str):
+        try:
+            return self.RUN_ARGS[(os.name, language)]
+        except KeyError:
+            raise ValueError(f"Language {language} on {os.name} OS is not supported.")
+
+    def execute_script(self, language: str, script: str) -> tuple[int, str, str]:
+        run_args = self._get_run_args(language)
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(script.encode("utf-8"))
+            f.flush()
+            result = subprocess.run([*run_args, f.name], capture_output=True)
+        return (
+            result.returncode,
+            result.stdout.decode("utf-8"),
+            result.stderr.decode("utf-8"),
+        )

--- a/etlman/backends/tests/test_subprocess_backend.py
+++ b/etlman/backends/tests/test_subprocess_backend.py
@@ -1,0 +1,68 @@
+import subprocess
+
+import pytest
+
+from etlman.backends.subprocess_backend import SubprocessBackend
+
+
+class TestPythonSubprocessBackend:
+    LANGUAGE = "python"
+    STDOUT_TEST = "out to stdout"
+    STDERR_TEST = "out to stderr"
+    TEST_SCRIPT = f"""
+import sys
+print("{STDERR_TEST}", file=sys.stderr)
+print("{STDOUT_TEST}", file=sys.stdout)
+sys.exit({{exitcode}})
+"""
+
+    def test_success(self):
+        backend = SubprocessBackend()
+        exitcode, stdout, stderr = backend.execute_script(
+            self.LANGUAGE, self.TEST_SCRIPT.format(exitcode=0)
+        )
+        assert stderr.strip() == self.STDERR_TEST
+        assert stdout.strip() == self.STDOUT_TEST
+        assert exitcode == 0
+
+    def test_failure(self):
+        backend = SubprocessBackend()
+        exitcode, stdout, stderr = backend.execute_script(
+            self.LANGUAGE, self.TEST_SCRIPT.format(exitcode=1)
+        )
+        assert stderr.strip() == self.STDERR_TEST
+        assert stdout.strip() == self.STDOUT_TEST
+        assert exitcode == 1
+
+
+@pytest.mark.skipif(
+    subprocess.run(["which", "Rscript"]).returncode != 0,
+    reason="requires Rscript to be installed",
+)
+class TestRScriptSubprocessBackend:
+    LANGUAGE = "r"
+    STDOUT_TEST = "out to stdout"
+    STDERR_TEST = "out to stderr"
+    TEST_SCRIPT = f"""
+write("{STDERR_TEST}", stderr())
+write("{STDOUT_TEST}", stdout())
+quit(status={{exitcode}})
+"""
+
+    def test_success(self):
+        backend = SubprocessBackend()
+        exitcode, stdout, stderr = backend.execute_script(
+            self.LANGUAGE, self.TEST_SCRIPT.format(exitcode=0)
+        )
+        assert stderr.strip() == self.STDERR_TEST
+        assert stdout.strip() == self.STDOUT_TEST
+        assert exitcode == 0
+
+    def test_failure(self):
+        backend = SubprocessBackend()
+        exitcode, stdout, stderr = backend.execute_script(
+            self.LANGUAGE, self.TEST_SCRIPT.format(exitcode=1)
+        )
+        assert stderr.strip() == self.STDERR_TEST
+        assert stdout.strip() == self.STDOUT_TEST
+        assert exitcode == 1

--- a/etlman/projects/models.py
+++ b/etlman/projects/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from etlman.backends import get_backend
 from etlman.users.models import User
 
 
@@ -59,6 +60,10 @@ class Step(models.Model):
 
     def __str__(self):
         return self.name
+
+    def run_script(self):
+        backend = get_backend()
+        return backend.execute_script(self.language, self.script)
 
     class Meta:
         constraints = [


### PR DESCRIPTION
This adds a simple `SubprocessBackend` that can be used for executing scripts written in Python and R.

Sample usage for issue #90:

```python
step = Step.objects.get(...)
exitcode, stdout, stderr = step.run_script()
# now, pass exitcode, stdout, stderr to the template for display
```

Fixes #119